### PR TITLE
Add select overflow

### DIFF
--- a/styles/form/dropdown.sass
+++ b/styles/form/dropdown.sass
@@ -132,7 +132,7 @@
         padding: 0
         width: 100%
         max-height: 350px
-        overflow: auto
+        overflow: hidden auto
         .item
             line-height: 21px
             padding: 8px 15px

--- a/styles/form/dropdown.sass
+++ b/styles/form/dropdown.sass
@@ -132,6 +132,7 @@
         padding: 0
         width: 100%
         max-height: 350px
+        overflow: auto
         .item
             line-height: 21px
             padding: 8px 15px


### PR DESCRIPTION
Otherwise we get the following:

![image](https://user-images.githubusercontent.com/69117259/90312305-0da8f680-df0c-11ea-8b35-3a52acb8b5fb.png)
