### PR TITLE
Showing "GetDeadline" only for not final deadlines

### DIFF
--- a/src/components/deadline.js
+++ b/src/components/deadline.js
@@ -32,7 +32,7 @@ class Deadline extends React.Component {
             date = this.state.result?.date || roomContractSet.deadline.date,
             isRequestPossible = !this.state.result;
 
-        if ((date === null) && isRequestPossible)
+        if (isRequestPossible && roomContractSet.deadline?.isFinal !== true)
             return (
                 <div class="info">
                     <div


### PR DESCRIPTION
How it should work:
Need to show "GetDeadline" button only if deadline object contains property "isFinal" set to false